### PR TITLE
add missing dependency in env.sh

### DIFF
--- a/src/env.sh
+++ b/src/env.sh
@@ -8,6 +8,7 @@ fi
 PKG_REQS="
     goprotobuf.googlecode.com/hg/proto
     github.com/bmizerany/assert
+    github.com/ha/doozer
 "
 
 CMD_REQS="


### PR DESCRIPTION
peer.go requires ha/doozer
