### PR TITLE
insert the node id into /ctl/cal to choose which node becomes a CAL

### DIFF
--- a/src/pkg/peer/peer.go
+++ b/src/pkg/peer/peer.go
@@ -223,6 +223,8 @@ func activate(st *store.Store, self string, c *doozer.Conn) int64 {
 				continue
 			}
 			return seqn
+		} else if ev.IsSet() && ev.Body == self {
+			return ev.Seqn
 		}
 	}
 


### PR DESCRIPTION
Added support for choosing which slave is promoted to a paxos participant.  The existing behavior of inserting '' to have servers self select is unchanged.
