### PR TITLE
go sources updated for r59

### DIFF
--- a/src/pkg/consensus/manager.go
+++ b/src/pkg/consensus/manager.go
@@ -309,7 +309,7 @@ func getCals(g store.Getter) []string {
 	}
 
 	cals = cals[0:i]
-	sort.SortStrings(cals)
+	sort.Strings(cals)
 
 	return cals
 }
@@ -337,7 +337,7 @@ func fmtRuns(rs map[int64]*run) (s string) {
 	for i := range rs {
 		ns = append(ns, int(i))
 	}
-	sort.SortInts(ns)
+	sort.Ints(ns)
 	for _, i := range ns {
 		r := rs[int64(i)]
 		if r.l.done {

--- a/src/pkg/member/member_test.go
+++ b/src/pkg/member/member_test.go
@@ -50,6 +50,6 @@ func TestMemberSimple(t *testing.T) {
 	assert.T(t, ev.IsDel())
 	cs = append(cs, int(ev.Path[len(ev.Path)-1]))
 
-	sort.SortInts(cs)
+	sort.Ints(cs)
 	assert.Equal(t, []int{'x', 'y'}, cs)
 }

--- a/src/pkg/peer/bench_test.go
+++ b/src/pkg/peer/bench_test.go
@@ -2,7 +2,7 @@ package peer
 
 import (
 	"doozer/store"
-	"github.com/ha/doozer"
+	"github.com/nightmouse/doozer"
 	"testing"
 )
 

--- a/src/pkg/peer/misc_test.go
+++ b/src/pkg/peer/misc_test.go
@@ -2,7 +2,7 @@ package peer
 
 import (
 	_ "doozer/quiet"
-	"github.com/ha/doozer"
+	"github.com/nightmouse/doozer"
 	"net"
 )
 

--- a/src/pkg/peer/peer.go
+++ b/src/pkg/peer/peer.go
@@ -7,7 +7,7 @@ import (
 	"doozer/server"
 	"doozer/store"
 	"doozer/web"
-	"github.com/ha/doozer"
+	"github.com/nightmouse/doozer"
 	"net"
 	"os"
 	"time"

--- a/src/pkg/peer/peer_test.go
+++ b/src/pkg/peer/peer_test.go
@@ -2,7 +2,7 @@ package peer
 
 import (
 	"doozer/store"
-	"github.com/ha/doozer"
+	"github.com/nightmouse/doozer"
 	"exec"
 	"github.com/bmizerany/assert"
 	"os"

--- a/src/pkg/peer/prof.go
+++ b/src/pkg/peer/prof.go
@@ -2,7 +2,7 @@ package peer
 
 import (
 	"doozer/store"
-	"github.com/ha/doozer"
+	"github.com/nightmouse/doozer"
 	"testing"
 )
 

--- a/src/pkg/server/txn.go
+++ b/src/pkg/server/txn.go
@@ -210,7 +210,7 @@ func (t *txn) getdir() {
 			return
 		}
 
-		sort.SortStrings(ents)
+		sort.Strings(ents)
 		offset := int(*t.req.Offset)
 		if offset < 0 || offset >= len(ents) {
 			t.respondErrCode(response_RANGE)

--- a/src/pkg/store/getter.go
+++ b/src/pkg/store/getter.go
@@ -56,7 +56,7 @@ func walk(g Getter, path string, glob *Glob, f Visitor) (stopped bool) {
 		path = ""
 	}
 
-	sort.SortStrings(v)
+	sort.Strings(v)
 	for _, ent := range v {
 		stopped = walk(g, path+"/"+ent, glob, f)
 		if stopped {

--- a/src/pkg/store/getter_test.go
+++ b/src/pkg/store/getter_test.go
@@ -54,7 +54,7 @@ func TestWalk(t *testing.T) {
 	for p := range exp {
 		expPaths = append(expPaths, p)
 	}
-	sort.SortStrings(expPaths)
+	sort.Strings(expPaths)
 
 	st := New()
 	st.Ops <- Op{1, MustEncodeSet("/d/x", "1", Clobber)}
@@ -106,7 +106,7 @@ func TestWalkStop(t *testing.T) {
 	for p := range exp {
 		expPaths = append(expPaths, p)
 	}
-	sort.SortStrings(expPaths)
+	sort.Strings(expPaths)
 
 	st := New()
 	st.Ops <- Op{1, MustEncodeSet("/d/x", "1", Clobber)}

--- a/src/pkg/store/store.go
+++ b/src/pkg/store/store.go
@@ -110,7 +110,7 @@ func split(path string) []string {
 	if path == "/" {
 		return []string{}
 	}
-	return strings.Split(path[1:], "/", -1)
+	return strings.Split(path[1:], "/")
 }
 
 func join(parts []string) string {
@@ -170,7 +170,7 @@ func MustEncodeDel(path string, rev int64) (mutation string) {
 }
 
 func decode(mutation string) (path, v string, rev int64, keep bool, err os.Error) {
-	cm := strings.Split(mutation, ":", 2)
+	cm := strings.SplitN(mutation, ":", 2)
 
 	if len(cm) != 2 {
 		err = ErrBadMutation
@@ -182,7 +182,7 @@ func decode(mutation string) (path, v string, rev int64, keep bool, err os.Error
 		return
 	}
 
-	kv := strings.Split(cm[1], "=", 2)
+	kv := strings.SplitN(cm[1], "=", 2)
 
 	if err = checkPath(kv[0]); err != nil {
 		return

--- a/src/pkg/store/store_test.go
+++ b/src/pkg/store/store_test.go
@@ -396,7 +396,7 @@ func TestGetWithDir(t *testing.T) {
 	sync(st, 2)
 	dents, rev := st.Get("/")
 	assert.Equal(t, Dir, rev)
-	sort.SortStrings(dents)
+	sort.Strings(dents)
 	assert.Equal(t, []string{"x", "y"}, dents)
 }
 


### PR DESCRIPTION
./src/pkg/member/member_test.go: fixed sorthelpers
./src/pkg/store/store.go: fixed stringssplit
./src/pkg/store/getter.go: fixed sorthelpers
./src/pkg/store/store_test.go: fixed sorthelpers
./src/pkg/store/getter_test.go: fixed sorthelpers
./src/pkg/consensus/manager.go: fixed sorthelpers
./src/pkg/server/txn.go: fixed sorthelpers
