### PR TITLE
fix for issue #5 (web interface issues)

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -88,7 +88,7 @@ func evServer(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 			wevs <- ev
-			rev = ev.Rev
+			rev = ev.Seqn
 		}
 		close(wevs)
 	}()
@@ -113,7 +113,9 @@ func viewHtml(w http.ResponseWriter, r *http.Request) {
 
 func statsHtml(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "text/html")
-	statsTpl.Execute(w, runtime.MemStats)
+	memstats := new(runtime.MemStats)
+	runtime.ReadMemStats(memstats)
+	statsTpl.Execute(w, *memstats)
 }
 
 func walk(path string, st *store.Store, ch chan store.Event) {


### PR DESCRIPTION
the problem seemed to be that the server would infinite loop due to `nop` events having `rev == -3`... this commit prevents the state of `rev` in the websocket loop from ever going backwards.

ready for review @kr
