### PR TITLE
Fixes doozer image in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doozer
 
-![logo](/ha/doozerd/raw/master/doc/doozer.png)
+![logo](doc/doozer.png)
 
 ## What Is It?
 


### PR DESCRIPTION
Github recently changed relative linking, which broke this image.
