### PR TITLE
Update hacking.md  to point to http://localhost:8000 instead of http://localhost:8080

### DIFF
--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -40,7 +40,7 @@ components by running `go test` in that sub-package directory.
 ## Try It Out
 
     $ doozerd >/dev/null 2>&1 &
-    $ open http://localhost:8080/
+    $ open http://localhost:8000/
 
 This will start up one doozer process and show a web view of its contents.
 


### PR DESCRIPTION
By default, doozerd web starts up at http://localhost:8000, But the documentation (hacking.md) was pointing it to the wrong URL (http://localhost:8080)
