### PR TITLE
Go 1.1 compatibility, prevent hanging tests

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -68,9 +68,9 @@ func TestConsensusOne(t *testing.T) {
 func TestConsensusTwo(t *testing.T) {
 	a := "a"
 	b := "b"
-	x := &net.UDPAddr{net.IP{1, 2, 3, 4}, 5}
+	x, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5")
 	xs := "1.2.3.4:5"
-	y := &net.UDPAddr{net.IP{2, 3, 4, 5}, 6}
+	y, _ := net.ResolveUDPAddr("udp", "2.3.4.5:6")
 	ys := "2.3.4.5:6"
 	const alpha = 1
 	st := store.New()

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -121,12 +121,11 @@ func TestConsensusTwo(t *testing.T) {
 
 	go func() {
 		for o := range aout {
-			o := o
 			if o.Addr.Port == x.Port && o.Addr.IP.Equal(x.IP) {
-				go func() { ain <- o }()
+				go func(o Packet) { ain <- o }(o)
 			} else {
 				o.Addr = x
-				go func() { bin <- o }()
+				go func(o Packet) { bin <- o }(o)
 			}
 		}
 	}()
@@ -134,10 +133,10 @@ func TestConsensusTwo(t *testing.T) {
 	go func() {
 		for o := range bout {
 			if o.Addr.Port == y.Port && o.Addr.IP.Equal(y.IP) {
-				go func() { bin <- o }()
+				go func(o Packet) { bin <- o }(o)
 			} else {
 				o.Addr = y
-				go func() { ain <- o }()
+				go func(o Packet) { ain <- o }(o)
 			}
 		}
 	}()

--- a/consensus/manager.go
+++ b/consensus/manager.go
@@ -60,6 +60,9 @@ func (t *triggers) Len() int {
 
 func (t *triggers) Less(i, j int) bool {
 	a := *t
+	if a[i].t == a[j].t {
+		return a[i].n < a[j].n
+	}
 	return a[i].t < a[j].t
 }
 

--- a/consensus/run_test.go
+++ b/consensus/run_test.go
@@ -13,6 +13,15 @@ const (
 	cal  = "/ctl/cal"
 )
 
+func MustResolveUDPAddr(n, addr string) *net.UDPAddr {
+	udp, err := net.ResolveUDPAddr(n, addr)
+	if err != nil {
+		panic(err)
+	}
+
+	return udp
+}
+
 type msgSlot struct {
 	*msg
 }
@@ -45,7 +54,7 @@ func TestRunVoteDelivered(t *testing.T) {
 			Vrnd:  proto.Int64(1),
 			Value: []byte("foo"),
 		},
-		Addr: &net.UDPAddr{net.IP{1, 2, 3, 4}, 5},
+		Addr: MustResolveUDPAddr("udp", "1.2.3.4:5"),
 	}
 
 	r.update(&p, 0, new(triggers))
@@ -75,8 +84,8 @@ func TestRunProposeDelivered(t *testing.T) {
 
 func TestRunSendsCoordPacket(t *testing.T) {
 	c := make(chan Packet, 100)
-	x := &net.UDPAddr{net.IP{1, 2, 3, 4}, 5}
-	y := &net.UDPAddr{net.IP{2, 3, 4, 5}, 6}
+	x := MustResolveUDPAddr("udp", "1.2.3.4:5")
+	y := MustResolveUDPAddr("udp", "2.3.4.5:6")
 	var r run
 	r.c.crnd = 1
 	r.out = c
@@ -111,8 +120,8 @@ func TestRunSchedulesTick(t *testing.T) {
 
 func TestRunSendsAcceptorPacket(t *testing.T) {
 	c := make(chan Packet, 100)
-	x := &net.UDPAddr{net.IP{1, 2, 3, 4}, 5}
-	y := &net.UDPAddr{net.IP{2, 3, 4, 5}, 6}
+	x := MustResolveUDPAddr("udp", "1.2.3.4:5")
+	y := MustResolveUDPAddr("udp", "2.3.4.5:6")
 	var r run
 	r.out = c
 	r.addr = []*net.UDPAddr{x, y}
@@ -174,9 +183,9 @@ func TestRunBroadcastThree(t *testing.T) {
 	r.seqn = 1
 	r.out = c
 	r.addr = []*net.UDPAddr{
-		&net.UDPAddr{net.IP{1, 2, 3, 4}, 5},
-		&net.UDPAddr{net.IP{2, 3, 4, 5}, 6},
-		&net.UDPAddr{net.IP{3, 4, 5, 6}, 7},
+		MustResolveUDPAddr("udp", "1.2.3.4:5"),
+		MustResolveUDPAddr("udp", "2.3.4.5:6"),
+		MustResolveUDPAddr("udp", "3.4.5.6:7"),
 	}
 
 	r.broadcast(newInvite(1))
@@ -208,11 +217,11 @@ func TestRunBroadcastFive(t *testing.T) {
 	r.seqn = 1
 	r.out = c
 	r.addr = []*net.UDPAddr{
-		&net.UDPAddr{net.IP{1, 2, 3, 4}, 5},
-		&net.UDPAddr{net.IP{2, 3, 4, 5}, 6},
-		&net.UDPAddr{net.IP{3, 4, 5, 6}, 7},
-		&net.UDPAddr{net.IP{4, 5, 6, 7}, 8},
-		&net.UDPAddr{net.IP{5, 6, 7, 8}, 9},
+		MustResolveUDPAddr("udp", "1.2.3.4:5"),
+		MustResolveUDPAddr("udp", "2.3.4.5:6"),
+		MustResolveUDPAddr("udp", "3.4.5.6:7"),
+		MustResolveUDPAddr("udp", "4.5.6.7:8"),
+		MustResolveUDPAddr("udp", "5.6.7.8:9"),
 	}
 
 	r.broadcast(newInvite(1))
@@ -243,9 +252,9 @@ func TestRunBroadcastNil(t *testing.T) {
 	var r run
 	r.out = c
 	r.addr = []*net.UDPAddr{
-		&net.UDPAddr{net.IP{1, 2, 3, 4}, 5},
-		&net.UDPAddr{net.IP{2, 3, 4, 5}, 6},
-		&net.UDPAddr{net.IP{3, 4, 5, 6}, 7},
+		MustResolveUDPAddr("udp", "1.2.3.4:5"),
+		MustResolveUDPAddr("udp", "2.3.4.5:6"),
+		MustResolveUDPAddr("udp", "3.4.5.6:7"),
 	}
 
 	r.broadcast(nil)

--- a/peer/liveness_test.go
+++ b/peer/liveness_test.go
@@ -30,7 +30,7 @@ func TestLivenessMark(t *testing.T) {
 
 func TestLivenessStaysAlive(t *testing.T) {
 	shun := make(chan string, 1)
-	a := &net.UDPAddr{net.IP{1, 2, 3, 4}, 5}
+	a, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5")
 	lv := liveness{
 		prev:    0,
 		ival:    1,
@@ -46,14 +46,15 @@ func TestLivenessStaysAlive(t *testing.T) {
 
 func TestLivenessTimesOut(t *testing.T) {
 	shun := make(chan string, 1)
-	a := &net.UDPAddr{net.IP{1, 2, 3, 4}, 5}
+	a, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5")
+	b, _ := net.ResolveUDPAddr("udp", "2.3.4.5:6")
 	lv := liveness{
 		prev:    0,
 		ival:    1,
 		timeout: 3,
 		times:   []liverec{{a, 5}},
 		shun:    shun,
-		self:    &net.UDPAddr{net.IP{2, 3, 4, 5}, 6},
+		self:    b,
 	}
 	lv.check(9)
 	assert.Equal(t, int64(9), lv.prev)
@@ -64,7 +65,7 @@ func TestLivenessTimesOut(t *testing.T) {
 
 func TestLivenessSelfStaysAlive(t *testing.T) {
 	shun := make(chan string, 1)
-	a := &net.UDPAddr{net.IP{1, 2, 3, 4}, 5}
+	a, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5")
 	lv := liveness{
 		prev:    0,
 		ival:    1,
@@ -80,7 +81,7 @@ func TestLivenessSelfStaysAlive(t *testing.T) {
 }
 
 func TestLivenessNoCheck(t *testing.T) {
-	a := &net.UDPAddr{net.IP{1, 2, 3, 4}, 5}
+	a, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5")
 	lv := liveness{
 		prev:  5,
 		ival:  3,

--- a/quiet/quiet.go
+++ b/quiet/quiet.go
@@ -2,18 +2,9 @@ package quiet
 
 import (
 	"log"
-	"os"
+	"io/ioutil"
 )
 
 func init() {
-	// TODO: if this is switched to ioutil.Discard a few of the tests hang.
-	// Presumably this means that there are legitimate deadlock issues 
-	// somewhere in the core...
-	// OSX 10.8.2 go1.0.3
-	// (GOMAXPROCS > 1 also resolves the issue indicating the same)
-	dn, err := os.OpenFile(os.DevNull, 0, 0)
-	if err != nil {
-		panic(err)
-	}
-	log.SetOutput(dn)
+	log.SetOutput(ioutil.Discard)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -18,7 +18,7 @@ func ListenAndServe(l net.Listener, canWrite chan bool, st *store.Store, p conse
 			if err == syscall.EINVAL {
 				break
 			}
-			if e, ok := err.(*net.OpError); ok && e.Err == syscall.EINVAL {
+			if e, ok := err.(*net.OpError); ok && !e.Temporary() {
 				break
 			}
 			log.Println(err)


### PR DESCRIPTION
This includes a few changes:
1. General test fixes to get everything running on go1.1 (chiefly, removing explicit allocations of `*net.UDPAddr`.
2. `server.ListenAndServe` aborts on all non-temporary network errors, not just `syscall.EINVAL`. This was a cause of randomly hanging tests with quiet logging. When the listen socket was closed from a defer() statement in the tests, it would enter an infinite failure loop, attempting to log the error message -- which, when using ioutil.Discard, was not guaranteed to trigger the scheduler, resulting in 100% CPU usage from the serve goroutine and a hanging process.
3. Change `conensensus.triggers.Less()` to consider both timestamp and sequence number. The current implementation depends on undefined behaviour in `container/heap` which differs between go1.0.3 and go1.1.

I'd appreciate feedback on 2 and 3: though all tests pass with the changes, I could imagine consequences that aren't covered by the tests.
