### PR TITLE
bug fix: no more panic when from<0

### DIFF
--- a/consensus/coordinator.go
+++ b/consensus/coordinator.go
@@ -55,7 +55,7 @@ func (co *coordinator) update(p *packet, from int) (m *msg, wantTick bool) {
 			co.vv = string(vval)
 		}
 
-		if !co.rsvp[from] {
+		if from>-1 && !co.rsvp[from] {
 			co.rsvp[from] = true
 			co.nrsvp++
 		}


### PR DESCRIPTION
When starting doozerd with -l=":8046" then the program crashes because a message is handled here with "from" = -1 (unidentified UDP/TCP source).
